### PR TITLE
修改调用方式为流式，避免服务网关请求超时

### DIFF
--- a/lib/kaba/application.rb
+++ b/lib/kaba/application.rb
@@ -10,11 +10,12 @@ class Application
 
     def llm_client
       @llm_client ||= OpenAI::Client.new(
+        log_errors: true,
         access_token: env!("LISA_ACCESS_TOKEN"),
         request_timeout: ENV.fetch("LISA_LLM_REQUEST_TIMEOUT", 120).to_i,
         uri_base: ENV.fetch("LISA_LLM_URI_BASE", "https://api.listenai.com")
       ) do |faraday|
-        faraday.adapter :async_http, clients: Async::HTTP::Faraday::PersistentClients
+        faraday.adapter Faraday.default_adapter, clients: Async::HTTP::Faraday::PersistentClients
       end
     end
 

--- a/lib/kaba/test_runner.rb
+++ b/lib/kaba/test_runner.rb
@@ -46,14 +46,17 @@ class TestRunner
           #{JSON.pretty_generate(JSON.parse(File.read(row.target_path)))}
           ```
           Markdown
-          output = Application.llm_client.chat(
+          output = ""
+          Application.llm_client.chat(
             parameters: {
               model: model,
               messages: [ { role: 'user', content: input } ],
               temperature: temperature,
+              stream: proc do |chunk, _bytesize|
+                output += chunk.dig("choices", 0, "delta", "content")
+              end
             }
-          ).dig("choices", 0, "message", "content")
-          
+          )
 
           output_json = JSON.parse_llm_response output
 


### PR DESCRIPTION
1. 增加错误日志输出，便于定位问题
2. 修改faraday adapter 为默认调用，以兼容 stream 调用
3. output 输出调整为 stream 拼接